### PR TITLE
Refactor `model` modules structs to use `Arc<str>` instead of plain (mutable) `String` to allow cheap cloning in case when it is needed.

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ use prost_types::Timestamp;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct TokenKey {
-    pub key: Arc<String>,
+    pub key: Arc<str>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -40,7 +40,7 @@ impl From<&TokenKey> for cm::TokenKey {
 impl From<cm::TokenKey> for TokenKey {
     fn from(source: cm::TokenKey) -> Self {
         Self {
-            key: Arc::new(source.key),
+            key: Arc::from(source.key),
         }
     }
 }
@@ -94,9 +94,9 @@ impl From<TokenKey> for Token {
 }
 
 impl TokenKey {
-    pub fn new(key: impl Into<String>) -> Self {
+    pub fn new(key: &str) -> Self {
         Self {
-            key: Arc::new(key.into()),
+            key: Arc::from(key),
         }
     }
 }

--- a/src/rpc/cm_message.rs
+++ b/src/rpc/cm_message.rs
@@ -157,6 +157,9 @@ impl CmMessage for CmMessageService {
         let mut subscribe_rx = self.subscribe_tx.subscribe();
         tokio::spawn(async move {
             while let Ok(update) = subscribe_rx.recv().await {
+
+                info!("message recv");
+
                 // Match the defined operation and handle the set logic.
                 if let Some(operation) = update.clone().operation {
                     match operation {


### PR DESCRIPTION
Signed-off-by: osk <svn.gv@protonmail.com>